### PR TITLE
lt cleanup and more variables

### DIFF
--- a/launch_template.tf
+++ b/launch_template.tf
@@ -33,6 +33,8 @@ resource "aws_launch_template" "lt" {
 }
 
 # default launch template for salt backed ASG's
+# including OFS password and key and sendgrid API key
+# since salt has troubles with param store
 
 locals {
   cloud_init = <<EOF
@@ -54,7 +56,7 @@ locals {
         permissions: "0400"
         owner: "root"
       - path: "/etc/objectivefs.env/DISKCACHE_SIZE"
-        content: "50G"
+        content: "${var.ofs_cache_size}"
         permissions: "0400"
         owner: "root"
       - path: "/etc/objectivefs.env/DISKCACHE_PATH"
@@ -95,20 +97,13 @@ locals {
         owner: "root:root"
         content: |
           [smtp.sendgrid.net]:587 apikey:${var.sendgrid_api_key}
-      - path: "/etc/postfix/main.cf"
-        permissions: 0644
-        owner: "root:root"
-        encoding: b64
-        content: bXlob3N0bmFtZSA9IGxvY2FsaG9zdApteWRlc3RpbmF0aW9uID0gbG9jYWxob3N0CmluZXRfaW50ZXJmYWNlcyA9IGxvb3BiYWNrLW9ubHkKaW5ldF9wcm90b2NvbHMgPSBhbGwKc210cGRfdGxzX2NlcnRfZmlsZSA9IC9ldGMvc3NsL2NlcnRzL3NzbC1jZXJ0LXNuYWtlb2lsLnBlbQpzbXRwZF90bHNfa2V5X2ZpbGUgPSAvZXRjL3NzbC9wcml2YXRlL3NzbC1jZXJ0LXNuYWtlb2lsLmtleQpzbXRwZF90bHNfc2VjdXJpdHlfbGV2ZWwgPSBtYXkKc210cF90bHNfc2VjdXJpdHlfbGV2ZWwgPSBlbmNyeXB0CnNtdHBfdGxzX0NBcGF0aCA9IC9ldGMvc3NsL2NlcnRzCnNtdHBkX3Nhc2xfYXV0aF9lbmFibGUgPSB5ZXMKc210cGRfc2FzbF9zZWN1cml0eV9vcHRpb25zID0gbm9hbm9ueW1vdXMsIG5vcGxhaW50ZXh0CnNtdHBkX3Nhc2xfdGxzX3NlY3VyaXR5X29wdGlvbnMgPSBub2Fub255bW91cwpzbXRwZF90bHNfYXV0aF9vbmx5ID0geWVzCnJlbGF5aG9zdCA9IFtzbXRwLnNlbmRncmlkLm5ldF06NTg3CnNtdHBfc2FzbF9wYXNzd29yZF9tYXBzID0gaGFzaDovZXRjL3Bvc3RmaXgvc2FzbF9wYXNzd2QKc210cGRfcmVjaXBpZW50X3Jlc3RyaWN0aW9ucyA9IHBlcm1pdF9teW5ldHdvcmtzLCBwZXJtaXRfc2FzbF9hdXRoZW50aWNhdGVkLCByZWplY3RfdW5hdXRoX2Rlc3RpbmF0aW9uCnNtdHBkX3JlbGF5X3Jlc3RyaWN0aW9ucyA9IHBlcm1pdF9teW5ldHdvcmtzLCBwZXJtaXRfc2FzbF9hdXRoZW50aWNhdGVkLCBkZWZlcl91bmF1dGhfZGVzdGluYXRpb24KYWxpYXNfbWFwcyA9IGhhc2g6L2V0Yy9hbGlhc2VzCmFsaWFzX2RhdGFiYXNlID0gaGFzaDovZXRjL2FsaWFzZXMKbWVzc2FnZV9zaXplX2xpbWl0ID0gNDE5NDMwNDAKaGVhZGVyX3NpemVfbGltaXQgPSA0MDk2MDAwCmRpc2FibGVfdnJmeV9jb21tYW5kID0geWVzCg==
     runcmd:
       - echo "id:" $(/bin/jq -r .v1.instance_id /var/run/cloud-init/instance-data.json) >> /etc/salt/minion.d/id.conf
       - mkdir -p /var/cache/ofs
       - mkdir -p /var/www
-      - postmap /etc/postfix/sasl_passwd
       - |
         echo "s3://${var.ofs_bucket}/www /var/www objectivefs _netdev,acl,auto,mboost,mt,nonempty 0 0" >> /etc/fstab
       - mount -a
-      - systemctl --now enable postfix
       - systemctl --now enable salt-minion.service
   EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,12 +20,13 @@ variable "security_groups" {
 }
 variable "ec2_iam_profile" {}
 variable "ebs_volume_size" { default = "150" }
-variable "ofs_license" {}
-variable "ofs_passphrase" {}
+variable "ofs_license" { default = "" }
+variable "ofs_passphrase" { default = "" }
+variable "ofs_cache_size" { default = "100G" }
 variable "vpc_id" {}
 variable "suffix" {}
 variable "group_name" {}
-variable "sendgrid_api_key" {}
+variable "sendgrid_api_key" { default = "" }
 variable "yaml_files" {
   type = list(string)
 }


### PR DESCRIPTION
1. removed postfix config - will manage with salt
2. keeping ofs and sendgrid secrets because salt does not play nice with paramstore and this is a cleaner way to input secrets
3. set empty defaults for some vars - as they might not always be used
4. made OFS cache size a var