### PR TITLE
mount is not always www

### DIFF
--- a/launch_template.tf
+++ b/launch_template.tf
@@ -102,7 +102,7 @@ locals {
       - mkdir -p /var/cache/ofs
       - mkdir -p /var/www
       - |
-        echo "s3://${var.ofs_bucket}/www /var/www objectivefs _netdev,acl,auto,mboost,mt,nonempty 0 0" >> /etc/fstab
+        echo "s3://${var.ofs_bucket} /var/www objectivefs _netdev,acl,auto,mboost,mt,nonempty 0 0" >> /etc/fstab
       - mount -a
       - systemctl --now enable salt-minion.service
   EOF


### PR DESCRIPTION
OFS pool is not always www - the pool will need to be part of the OFS Variable ie: $bucket/pool