### PR TITLE
adding output for TG ARN

### DIFF
--- a/ouptputs.tf
+++ b/ouptputs.tf
@@ -1,0 +1,4 @@
+output "tg_arn_suffix" {
+  value       = aws_lb_target_group.tg.arn_suffix
+  description = "The Target Groups ARN Suffix"
+}


### PR DESCRIPTION
This will add an output for the Target Group ARN to be used with cloudwatch alarms