### PR TITLE
Instance maintenace policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.18 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.18 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.27 |
 
 ## Modules
 
@@ -53,29 +53,34 @@
 | <a name="input_environments"></a> [environments](#input\_environments) | n/a | `list(string)` | n/a | yes |
 | <a name="input_group_name"></a> [group\_name](#input\_group\_name) | n/a | `any` | n/a | yes |
 | <a name="input_ofs_bucket"></a> [ofs\_bucket](#input\_ofs\_bucket) | n/a | `any` | n/a | yes |
-| <a name="input_ofs_license"></a> [ofs\_license](#input\_ofs\_license) | n/a | `any` | n/a | yes |
-| <a name="input_ofs_passphrase"></a> [ofs\_passphrase](#input\_ofs\_passphrase) | n/a | `any` | n/a | yes |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | n/a | `list(string)` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | n/a | `any` | n/a | yes |
 | <a name="input_salt_roles"></a> [salt\_roles](#input\_salt\_roles) | n/a | `list(string)` | n/a | yes |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | n/a | `list(string)` | n/a | yes |
-| <a name="input_sendgrid_api_key"></a> [sendgrid\_api\_key](#input\_sendgrid\_api\_key) | n/a | `any` | n/a | yes |
 | <a name="input_suffix"></a> [suffix](#input\_suffix) | n/a | `any` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `any` | n/a | yes |
 | <a name="input_yaml_files"></a> [yaml\_files](#input\_yaml\_files) | n/a | `list(string)` | n/a | yes |
 | <a name="input_automate_instance_refresh"></a> [automate\_instance\_refresh](#input\_automate\_instance\_refresh) | n/a | `bool` | `false` | no |
+| <a name="input_cooldown"></a> [cooldown](#input\_cooldown) | n/a | `string` | `"900"` | no |
 | <a name="input_cpu_value"></a> [cpu\_value](#input\_cpu\_value) | n/a | `string` | `"60"` | no |
-| <a name="input_create_certificates"></a> [create\_certificates](#input\_create\_certificates) | n/a | `bool` | `true` | no |
 | <a name="input_create_route53_records"></a> [create\_route53\_records](#input\_create\_route53\_records) | n/a | `bool` | `true` | no |
+| <a name="input_create_ssl_certificates"></a> [create\_ssl\_certificates](#input\_create\_ssl\_certificates) | n/a | `bool` | `true` | no |
 | <a name="input_ebs_volume_size"></a> [ebs\_volume\_size](#input\_ebs\_volume\_size) | n/a | `string` | `"150"` | no |
 | <a name="input_instance_lifetime"></a> [instance\_lifetime](#input\_instance\_lifetime) | n/a | `string` | `"1209600"` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3a.medium"` | no |
 | <a name="input_launch_template_file"></a> [launch\_template\_file](#input\_launch\_template\_file) | n/a | `string` | `""` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | n/a | `string` | `"10"` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | n/a | `string` | `"1"` | no |
+| <a name="input_ofs_cache_size"></a> [ofs\_cache\_size](#input\_ofs\_cache\_size) | n/a | `string` | `"100G"` | no |
+| <a name="input_ofs_license"></a> [ofs\_license](#input\_ofs\_license) | n/a | `string` | `""` | no |
+| <a name="input_ofs_passphrase"></a> [ofs\_passphrase](#input\_ofs\_passphrase) | n/a | `string` | `""` | no |
 | <a name="input_salt_master"></a> [salt\_master](#input\_salt\_master) | n/a | `string` | `"salt"` | no |
+| <a name="input_sendgrid_api_key"></a> [sendgrid\_api\_key](#input\_sendgrid\_api\_key) | n/a | `string` | `""` | no |
+| <a name="input_warmup"></a> [warmup](#input\_warmup) | n/a | `string` | `"120"` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_tg_arn_suffix"></a> [tg\_arn\_suffix](#output\_tg\_arn\_suffix) | The Target Groups ARN Suffix |
 <!-- END_TF_DOCS -->

--- a/asg.tf
+++ b/asg.tf
@@ -48,6 +48,11 @@ resource "aws_autoscaling_group" "asg" {
     lifecycle_transition = "autoscaling:EC2_INSTANCE_TERMINATING"
   }
 
+  instance_maintenance_policy {
+    min_healthy_percentage = 90
+    max_healthy_percentage = 120
+  }
+
   # This will enable automatic instance refresh if the automate_instance_refresh variable
   # is set to to true which will update instances when the launch template is changed
   # defaults to false

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.18"
+      version = "~> 5.27"
     }
   }
-  required_version = "~> 1.5"
+  required_version = "~> 1.6"
 }


### PR DESCRIPTION
As of November 2023 AWS has implemented a new feature called Instance maintenace policy which was added to the 5.25 and later terraform provider

https://docs.aws.amazon.com/autoscaling/ec2/userguide/set-instance-maintenance-policy-on-group.html

In theory, this feature should keep ASG's healthy during termination policies, IE when max_instances_lifetime is reached and create a new instance and insure it is healthy before the old instance is deleted