### PR TITLE
Yaml injestion loop

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,32 +2,19 @@
 # and convert hat information into a map for easy injestion by the module parts
 
 locals {
-  php_sites = flatten([
+  mapped_sites = flatten([
     for f in var.yaml_files : [
-      for name, site in try(yamldecode(file(f)).vhosts.sites, []) : [
-        for env, instance in site.instances : {
-          name           = name
-          env            = env
-          url            = try(instance.urls, null)
-          create_ssl     = try(instance.create_ssl, true)
-          create_route53 = try(instance.create_route53, true)
-        }
+      for type, host in yamldecode(file(f)) : [
+        for name, site in try(host.sites, []) : [
+          for env, instance in site.instances : {
+            name           = name
+            env            = env
+            url            = try(instance.urls, null)
+            create_ssl     = try(instance.create_ssl, null)
+            create_route53 = try(instance.create_route53, null)
+          }
+        ]
       ]
     ]
   ])
-  node_sites = flatten([
-    for f in var.yaml_files : [
-      for name, site in try(yamldecode(file(f)).node.sites, []) : [
-        for env, instance in site.instances : {
-          name           = name
-          env            = env
-          url            = try(instance.urls, null)
-          create_ssl     = try(instance.create_ssl, true)
-          create_route53 = try(instance.create_route53, true)
-        }
-      ]
-    ]
-  ])
-
-  mapped_sites = concat(local.node_sites, local.php_sites)
 }


### PR DESCRIPTION
This is a change to the part of terraform that pulls the yaml into a map.
This just makes it 1 loop instead of 2 loops and would accommodate different scenarios that would not match vhosts or node exclusively.
This will have no impact on the builds it just makes the code cleaner 